### PR TITLE
Add basic todo API (initial version)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,12 @@
+version: 1
+rules:
+  style:
+    prefer_const: true
+    semicolons: always
+    quotes: double
+  security:
+    no_eval: true
+    no_console_log: true
+  best_practices:
+    enforce_async_await: true
+    require_error_handling: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,9 +4,3 @@ rules:
     prefer_const: true
     semicolons: always
     quotes: double
-  security:
-    no_eval: true
-    no_console_log: true
-  best_practices:
-    enforce_async_await: true
-    require_error_handling: true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "node": true,
+    "es2021": true
+  },
+  "extends": ["eslint:recommended"],
+  "rules": {
+    "max-len": ["error", { "code": 20 }]
+  }
+}

--- a/index.js
+++ b/index.js
@@ -24,4 +24,22 @@ if (require.main === module) {
   });
 }
 
+app.use(express.json());
+
+// Add POST endpoint (deliberately not fully polished)
+app.post("/todos", (req, res) => {
+  const { task, done } = req.body;
+
+  // No input validation yet → CodeRabbit should flag this
+  const newTodo = {
+    id: todos.length + 1, // Potential ID bug if items are deleted
+    task, // Could be empty or not a string
+    done, // Could be undefined or not boolean
+  };
+
+  todos.push(newTodo);
+
+  res.status(201).json(newTodo);
+});
+
 module.exports = app;

--- a/index.js
+++ b/index.js
@@ -26,6 +26,9 @@ if (require.main === module) {
 
 app.use(express.json());
 
+const reallyLongLine =
+  "This line is definitely more than twenty characters asxasxasxasxasxasxasxasxasxasxasxasxasxasxasxasxasxasxasxasxasxasxasxasx"; // This line is too long
+
 // Add POST endpoint (deliberately not fully polished)
 app.post("/todos", (req, res) => {
   const { task, done } = req.body;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const app = express();
-const PORT = 3000;
+const PORT = Number(process.env.PORT) || 3000;
+const HOST = process.env.HOST || "0.0.0.0";
 
 let todos = [
   { id: 1, task: "Learn CodeRabbit", done: false },
@@ -12,6 +13,15 @@ app.get("/todos", (req, res) => {
   res.json(todos);
 });
 
-app.listen(PORT, () => {
-  console.log("Server running on http://localhost:3000"); // hardcoded string
-});
+if (require.main === module) {
+  const server = app.listen(PORT, HOST, () => {
+    const displayHost = HOST === "0.0.0.0" ? "localhost" : HOST;
+    console.log(`Server running on http://${displayHost}:${PORT}`);
+  });
+  server.on("error", (err) => {
+    console.error("Server error:", err);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = app;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,17 @@
+const express = require("express");
+const app = express();
+const PORT = 3000;
+
+let todos = [
+  { id: 1, task: "Learn CodeRabbit", done: false },
+  { id: 2, task: "Prepare for PALO IT interview", done: false },
+];
+
+// Missing error handling, hardcoded port, no eslint rules applied
+app.get("/todos", (req, res) => {
+  res.json(todos);
+});
+
+app.listen(PORT, () => {
+  console.log("Server running on http://localhost:3000"); // hardcoded string
+});

--- a/index.js
+++ b/index.js
@@ -43,3 +43,4 @@ app.post("/todos", (req, res) => {
 });
 
 module.exports = app;
+// dummy change

--- a/index.test.js
+++ b/index.test.js
@@ -1,0 +1,38 @@
+const request = require('supertest');
+const app = require('./index');
+
+describe('Sample Test Suite', () => {
+    test('hello world!', () => {
+        expect(1 + 1).toBe(2);
+    });
+});
+describe('GET /todos', () => {
+    test('should return the list of todos', async () => {
+        const res = await request(app).get('/todos');
+        expect(res.statusCode).toBe(200);
+        expect(Array.isArray(res.body)).toBe(true);
+        expect(res.body.length).toBeGreaterThanOrEqual(2);
+        expect(res.body[0]).toHaveProperty('id');
+        expect(res.body[0]).toHaveProperty('task');
+        expect(res.body[0]).toHaveProperty('done');
+    });
+});
+
+describe('POST /todos', () => {
+    test('should add a new todo and return it', async () => {
+        const newTodo = { task: 'Test POST endpoint', done: false };
+        const res = await request(app)
+            .post('/todos')
+            .send(newTodo)
+            .set('Accept', 'application/json');
+        expect(res.statusCode).toBe(201);
+        expect(res.body).toHaveProperty('id');
+        expect(res.body.task).toBe(newTodo.task);
+        expect(res.body.done).toBe(newTodo.done);
+
+        // Optionally verify the todo was added
+        const getRes = await request(app).get('/todos');
+        const added = getRes.body.find(todo => todo.task === newTodo.task);
+        expect(added).toBeDefined();
+    });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  testEnvironment: 'node',
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  testMatch: ['**/*.test.js'],
+  verbose: true
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public GET /todos returns a sample list of to-dos in JSON.
  * Public POST /todos accepts JSON bodies to create new to-dos (development-ready, no auth/validation).
  * App accepts JSON request bodies and logs a friendly startup message with resolved host/port.
  * Startup errors trigger a clean exit on failure.

* **Chores**
  * Added project style and linting configuration (includes stricter line-length and style rules).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->